### PR TITLE
Fix UnboundLocalError in example.py

### DIFF
--- a/delve/torchcallback.py
+++ b/delve/torchcallback.py
@@ -228,6 +228,7 @@ class CheckLayerSat(object):
                     layer_class = layer.__module__.split('.')[-1]
                 except:
                     raise "Layer {} is not supported".format(layer)
+                layer_type = layer._get_name().lower()
                 if layer_type == 'conv2d':
                     if self.include_conv:
                         self._add_conv_layer(layer)


### PR DESCRIPTION
The example had a problem:

```
$ python example.py 
Traceback (most recent call last):
  File "example.py", line 37, in <module>
    stats = CheckLayerSat('regression/h{}'.format(h), layers)
  File "/home/rivo/Projektid/pyconlt-delve/delve/delve/torchcallback.py", line 68, in __init__
    self.layers = self._get_layers(modules)
  File "/home/rivo/Projektid/pyconlt-delve/delve/delve/torchcallback.py", line 231, in _get_layers
    if layer_type == 'conv2d':
UnboundLocalError: local variable 'layer_type' referenced before assignment
```

This makes it runnable, please check the correctness though :-)