### PR TITLE
Disable save in example

### DIFF
--- a/delve/torchcallback.py
+++ b/delve/torchcallback.py
@@ -17,11 +17,11 @@ from delve.writers import CSVandPlottingWriter
 # from mdp.utils import CovarianceMatrix
 from delve.torch_utils import TorchCovarianceMatrix
 from delve.writers import STATMAP, CompositWriter, NPYWriter
+from writers import WRITERS
 
 logging.basicConfig(format='%(levelname)s:delve:%(message)s',
                     level=logging.INFO)
 
-WRITERS = ["csvplot", "plot", "plotcsv"]
 
 class CheckLayerSat(object):
     """Takes PyTorch module and records layer saturation,
@@ -381,7 +381,7 @@ class CheckLayerSat(object):
                     self._get_writer(save_to=saver, writers_args=writers_args))
             return CompositWriter(all_writers)
         if save_to in WRITERS:
-            writer = CSVandPlottingWriter(**writers_args)
+            writer = WRITERS[save_to](**writers_args)
         else:
             raise ValueError(
                 'Illegal argument for save_to "{}"'.format(save_to))

--- a/delve/writers.py
+++ b/delve/writers.py
@@ -8,7 +8,7 @@ import pickle as pkl
 import warnings
 from abc import ABC, abstractmethod
 from shutil import make_archive
-from typing import Callable, List, Tuple
+from typing import Callable, List, Tuple, Dict
 
 import matplotlib
 import numpy as np
@@ -381,6 +381,18 @@ class CSVandPlottingWriter(CSVWriter):
     def close(self):
         pass
 
+
+WRITERS: Dict[str, AbstractWriter] = {
+    "csv": CSVWriter,
+    "npy": NPYWriter,
+    "print": PrintWriter,
+    "tb": TensorBoardWriter,
+    "tensorboard": TensorBoardWriter,
+    "csvplotting": CSVandPlottingWriter,
+    "csvplot": CSVandPlottingWriter,
+    "plot": CSVandPlottingWriter,
+    "plotcsv": CSVandPlottingWriter
+}
 
 def extract_layer_stat(df,
                        epoch=19,

--- a/examples/example.py
+++ b/examples/example.py
@@ -39,7 +39,7 @@ for h in [3]:
     x, y, model = x.to(device), y.to(device), model.to(device)
 
     layers = [model.linear1, model.linear2]
-    stats = CheckLayerSat('regression/h{}'.format(h), save_to="plotcsv", modules=layers, device=device, stats=["lsat", "lsat_eval"])
+    stats = CheckLayerSat('regression/h{}'.format(h), save_to="csvplot", modules=layers, device=device, stats=["lsat", "lsat_eval"])
 
     loss_fn = torch.nn.MSELoss(size_average=False)
     optimizer = torch.optim.SGD(model.parameters(), lr=1e-4, momentum=0.9)


### PR DESCRIPTION
The big was fixed. For some reason, the system expected you to hand instances of writer objects (or list of writer objects) to the `save_to` argument and did only pass csv-plotting-writer in case of a matching string key.
I now added a mapping, which maps all instantiable writers to at least a single string key, which allows for easier configuration.
Setting `save_to=False`, however will result in a crash, which is intentional, since you need at least one sink to dump the resulting data in.
If you do not want a permanent effect in the hard drive I recommend `save_to="print"`
