### PR TITLE
Plots from example.py are empty

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -2,10 +2,10 @@ name: Tests
 
 on:
   push:
-    branches: [master]
+    branches: [master, develop]
     tags: [v*]
   pull_request:
-    branches: [master]
+    branches: [master, develop]
 
 jobs:
   miniconda:

--- a/delve/torchcallback.py
+++ b/delve/torchcallback.py
@@ -339,7 +339,7 @@ class CheckLayerSat(object):
         else:
             layer_name = name_prefix
             layer_type = layer_name
-            if not self._check_is_is_supported_layer(submodule):
+            if not self._check_is_supported_layer(submodule):
                 log.info(f"Skipping {layer_type}")
                 return layers
             if isinstance(submodule, Conv2d) and self.include_conv:
@@ -348,7 +348,7 @@ class CheckLayerSat(object):
             log.info('added layer {}'.format(layer_name))
             return layers
 
-    def _check_is_is_supported_layer(self, layer: torch.nn.Module) -> bool:
+    def _check_is_supported_layer(self, layer: torch.nn.Module) -> bool:
         return isinstance(layer, Conv2d) or isinstance(layer, Linear) or isinstance(layer, LSTM)
 
     def get_layers_recursive(self, modules: Union[list, torch.nn.Module]):
@@ -357,12 +357,12 @@ class CheckLayerSat(object):
                 modules, 'out_features'):
             # submodules = modules._modules  # OrderedDict
             layers = self.get_layer_from_submodule(modules, layers, '')
-        elif self._check_is_is_supported_layer(modules):
+        elif self._check_is_supported_layer(modules):
             for module in modules:
                 layers = self.get_layer_from_submodule(module, layers, type(module))
         else:
             for i, module in enumerate(modules):
-                layers = self.get_layer_from_submodule(module, layers, '' if not self._check_is_is_supported_layer(module) else f'Module-{i}-{type(module).__name__}')
+                layers = self.get_layer_from_submodule(module, layers, '' if not self._check_is_supported_layer(module) else f'Module-{i}-{type(module).__name__}')
         return layers
 
     def _get_writer(self, save_to, writers_args) -> \

--- a/examples/example.py
+++ b/examples/example.py
@@ -33,11 +33,16 @@ for h in [3]:
     # Create random Tensors to hold inputs and outputs
     x = torch.randn(N, D_in)
     y = torch.randn(N, D_out)
+    x_test = torch.randn(N, D_in)
+    y_test = torch.randn(N, D_out)
 
     model = TwoLayerNet(D_in, H, D_out)
 
     x, y, model = x.to(device), y.to(device), model.to(device)
+    x_test, y_test = x_test.to(device), y_test.to(device)
 
+    # You can  can watch specific layers by handing them to delve as a list.
+    # Also, you can hand over the entire Module-object to delve and let delve search for recordable layers.
     layers = [model.linear1, model.linear2]
     stats = CheckLayerSat('regression/h{}'.format(h), save_to="csvplot", modules=layers, device=device, stats=["lsat", "lsat_eval"])
 
@@ -46,15 +51,28 @@ for h in [3]:
     steps_iter = trange(20, desc='steps', leave=True, position=0)
     steps_iter.write("{:^80}".format(
         "Regression - TwoLayerNet - Hidden layer size {}".format(h)))
-    for _ in steps_iter:
+    for step in steps_iter:
+
+        # training step
+        model.train()
         y_pred = model(x)
         loss = loss_fn(y_pred, y)
-        steps_iter.set_description('loss=%g' % loss.data)
         optimizer.zero_grad()
         loss.backward()
         optimizer.step()
 
+        # test step
+        model.eval()
+        y_pred = model(x_test)
+        loss_test = loss_fn(y_pred, y_test)
+
+
+        # update statistics
+        steps_iter.set_description('loss=%g' % loss.item())
+        stats.add_scalar("train-loss", loss.item())
+        stats.add_scalar("test-loss", loss_test.item())
         stats.add_saturations()
+
     steps_iter.write('\n')
     stats.close()
     steps_iter.close()


### PR DESCRIPTION
Fixed the bug in question.
There are two factors with this.
First, the example did not contain a validation step, which results in no validation result being plotted / the plots being empty, since not data is present.
I also used this as an excuse to make the example more expressive, including things like metric logging and differentiated logging of validation and training saturation. Its only a few lines of code more but I think it helps to make thing clearer by quite a bit.

The second issue is located in Torch-Callback and concerns the case that a list of modules is handed to delve instead of a module containing submodules.
If in this case, any of the modules is a recordable layer, delve will assign and empty string as a name to these layers, which will result in lost updated of covariance matrices during the forward pass and general inconsistent behavior.
This was fixed by a small additional naming Scheme that ensures that no layers will not be assigned an empty string and that module names will be unique if contained in a list.
